### PR TITLE
Update install docs, and emphasize inventory in examples docs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,6 +7,27 @@ to the syntax of the commands and available options.
 For now please check the given examples below to learn more.
 
 
+Our example inventory file
+---------------------------
+
+We can use the following command to create our inventory file. This will
+automatically include all of the VMs in your Qubes. You'll have to re-run
+it after creating new VMs, if you want ansible to be able to work with them.
+
+.. warning:: Remember that the following command will rewrite the inventory file.
+
+
+::
+
+    ansible-3 localhost -m qubesos -a 'command=createinventory'
+
+Once you have an inventory file, you can run ansible playbooks like this:
+
+::
+
+    ansible-playbook-3 -i inventory my_playbook.yaml
+
+
 Make sure a vm is present
 -------------------------
 
@@ -59,7 +80,7 @@ Setting different property values to a given vm
         qubesos:
             guest: xchat2
             state: present
-           
+
         - name: Run the xchat2 VM
         qubesos:
             guest: xchat2
@@ -186,20 +207,6 @@ The following example will find all the vms with running state.
 
 
 In the same way you can find vms with *shutdown* or *paused* state.
-
-
-Our example inventory file
----------------------------
-
-We can use the following command to create our inventory file.
-
-.. warning:: Remember that the following command will rewrite the inventory file.
-
-
-::
-
-    ansible-3 localhost -m qubesos -a 'command=createinventory'
-
 
 
 Install a package and copy to file to the remote vm and fetch some file back

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,8 +44,8 @@ Use the following commands to copy it over in **dom0**.
 
     sudo su -
     mkdir -p /usr/share/ansible_module/conns
-    qvm-run --pass-io development /home/user/qubes_ansible/ansible_module/qubesos.py > /usr/share/ansible_module/qubesos.py
-    qvm-run --pass-io development /home/user/qubes_ansible/ansible_module/conns/qubes.py > /usr/share/ansible_module/conns/qubes.py
+    qvm-run --pass-io development 'cat /home/user/qubes_ansible/ansible_module/qubesos.py' > /usr/share/ansible_module/qubesos.py
+    qvm-run --pass-io development 'cat /home/user/qubes_ansible/ansible_module/conns/qubes.py' > /usr/share/ansible_module/conns/qubes.py
 
 
 Setup the configuration file
@@ -56,7 +56,7 @@ We will add the following two lines to ``/etc/ansible/ansible.cfg`` file.
 ::
 
     library = /usr/share/ansible_module/
-    connection_plugins = /usr/share/ansible_module/conns/ 
+    connection_plugins = /usr/share/ansible_module/conns/
 
 
 The above configuration file will help Ansible to find the module and the
@@ -69,4 +69,3 @@ TODO (open question on how to install it)
 
 Should we just make sure if any vm is in running state, then that file should be
 inside in the right place? or copy it over there?
-


### PR DESCRIPTION
This PR fixes a bug in the install docs, so now running the commands will copy the files into dom0 instead of trying to execute them on the development VM.

It also edits the examples docs to move the inventory creation section at the top and adds a bit more information. Following the examples at first was confusing to me because I needed an inventory first thing before I could run the same playbooks I was trying to write.