### PR TITLE
Need to be root to apply package updates

### DIFF
--- a/examples/update_all_templates.yaml
+++ b/examples/update_all_templates.yaml
@@ -1,5 +1,6 @@
 ---
 - hosts: templatevms
+  become: true
   tasks:
     - name: Update the TemplateVM
       package: name=* state=latest


### PR DESCRIPTION
Side note: although abstraction is nice, this playbook is IMO still not as functional as the `updates.yaml`, because apt cache is not being updated first in order to discover new package updates.

If we add `update_cache=yes` here, the fedora template will complain.